### PR TITLE
WebP support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "library/src/main/jni/test/check"]
 	path = library/src/main/jni/test/check
 	url = https://github.com/seven332/check-android-binaries.git
+[submodule "library/src/main/jni/webp/libwebp"]
+	path = library/src/main/jni/webp/libwebp
+	url = https://chromium.googlesource.com/webm/libwebp

--- a/library/src/main/java/com/hippo/image/Image.java
+++ b/library/src/main/java/com/hippo/image/Image.java
@@ -57,6 +57,11 @@ public final class Image {
      */
     public static final int FORMAT_GIF = 4;
 
+    /**
+     * WEBP image format
+     */
+    public static final int FORMAT_WEBP = 5;
+
     private static long mBuffer = 0;
     private static int mBufferSize;
 

--- a/library/src/main/jni/CMakeLists.txt
+++ b/library/src/main/jni/CMakeLists.txt
@@ -22,6 +22,7 @@ add_subdirectory(image)
 add_subdirectory(jpeg)
 add_subdirectory(png)
 add_subdirectory(gif)
+add_subdirectory(webp)
 add_subdirectory(test)
 
 unset(IMAGE_SINGLE_SHARED_LIB CACHE)

--- a/library/src/main/jni/image/CMakeLists.txt
+++ b/library/src/main/jni/image/CMakeLists.txt
@@ -57,6 +57,7 @@ if(IMAGE_SINGLE_SHARED_LIB)
         image-jpeg-static
         image-png-static
         image-gif-static
+        image-webp-static
     )
 else()
     set(IMAGE_LIBRARIES

--- a/library/src/main/jni/image/image.c
+++ b/library/src/main/jni/image/image.c
@@ -26,6 +26,7 @@
   #include "image_jpeg.h"
   #include "image_png.h"
   #include "image_gif.h"
+  #include "image_webp.h"
 #endif
 
 static ImageLibrary image_libraries[IMAGE_FORMAT_MAX_COUNT] = { 0 };
@@ -78,12 +79,14 @@ void init_image_libraries() {
   load_library_local("jpeg_init",  jpeg_init,  &image_libraries[IMAGE_FORMAT_JPEG]);
   load_library_local("png_init",   png_init,   &image_libraries[IMAGE_FORMAT_PNG]);
   load_library_local("gif_init",   gif_init,   &image_libraries[IMAGE_FORMAT_GIF]);
+  load_library_local("webp_init",  webp_init,  &image_libraries[IMAGE_FORMAT_WEBP]);
 #else
   load_library("libimage.so",      "plain_init", &image_libraries[IMAGE_FORMAT_PLAIN]);
   load_library("libimage.so",      "bmp_init",   &image_libraries[IMAGE_FORMAT_BMP]);
   load_library("libimage-jpeg.so", "jpeg_init",  &image_libraries[IMAGE_FORMAT_JPEG]);
   load_library("libimage-png.so",  "png_init",   &image_libraries[IMAGE_FORMAT_PNG]);
   load_library("libimage-gif.so",  "gif_init",   &image_libraries[IMAGE_FORMAT_GIF]);
+  load_library("libimage-webp.so", "webp_init",  &image_libraries[IMAGE_FORMAT_WEBP]);
 #endif
 }
 

--- a/library/src/main/jni/image/image.h
+++ b/library/src/main/jni/image/image.h
@@ -39,7 +39,9 @@
 
 #define IMAGE_FORMAT_GIF com_hippo_image_Image_FORMAT_GIF
 
-#define IMAGE_FORMAT_MAX_COUNT 5
+#define IMAGE_FORMAT_WEBP com_hippo_image_Image_FORMAT_WEBP
+
+#define IMAGE_FORMAT_MAX_COUNT 6
 
 void init_image_libraries();
 

--- a/library/src/main/jni/webp/CMakeLists.txt
+++ b/library/src/main/jni/webp/CMakeLists.txt
@@ -1,0 +1,119 @@
+# Copyright 2018 Hippo Seven
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cmake_minimum_required(VERSION 3.4.1)
+project(image-webp C)
+
+set(LIBWEBP_SOURCES
+    image_webp.c
+    libwebp/src/dec/alpha_dec.c
+    libwebp/src/dec/buffer_dec.c
+    libwebp/src/dec/frame_dec.c
+    libwebp/src/dec/idec_dec.c
+    libwebp/src/dec/io_dec.c
+    libwebp/src/dec/quant_dec.c
+    libwebp/src/dec/tree_dec.c
+    libwebp/src/dec/vp8_dec.c
+    libwebp/src/dec/vp8l_dec.c
+    libwebp/src/dec/webp_dec.c
+    libwebp/src/demux/anim_decode.c
+    libwebp/src/demux/demux.c
+    libwebp/src/dsp/alpha_processing.c
+    libwebp/src/dsp/alpha_processing_mips_dsp_r2.c
+    libwebp/src/dsp/alpha_processing_neon.c
+    libwebp/src/dsp/alpha_processing_sse2.c
+    libwebp/src/dsp/alpha_processing_sse41.c
+    libwebp/src/dsp/cpu.c
+    libwebp/src/dsp/dec.c
+    libwebp/src/dsp/dec_clip_tables.c
+    libwebp/src/dsp/dec_mips32.c
+    libwebp/src/dsp/dec_mips_dsp_r2.c
+    libwebp/src/dsp/dec_msa.c
+    libwebp/src/dsp/dec_neon.c
+    libwebp/src/dsp/dec_sse2.c
+    libwebp/src/dsp/dec_sse41.c
+    libwebp/src/dsp/filters.c
+    libwebp/src/dsp/filters_mips_dsp_r2.c
+    libwebp/src/dsp/filters_msa.c
+    libwebp/src/dsp/filters_neon.c
+    libwebp/src/dsp/filters_sse2.c
+    libwebp/src/dsp/lossless.c
+    libwebp/src/dsp/lossless_mips_dsp_r2.c
+    libwebp/src/dsp/lossless_msa.c
+    libwebp/src/dsp/lossless_neon.c
+    libwebp/src/dsp/lossless_sse2.c
+    libwebp/src/dsp/rescaler.c
+    libwebp/src/dsp/rescaler_mips32.c
+    libwebp/src/dsp/rescaler_mips_dsp_r2.c
+    libwebp/src/dsp/rescaler_msa.c
+    libwebp/src/dsp/rescaler_neon.c
+    libwebp/src/dsp/rescaler_sse2.c
+    libwebp/src/dsp/upsampling.c
+    libwebp/src/dsp/upsampling_mips_dsp_r2.c
+    libwebp/src/dsp/upsampling_msa.c
+    libwebp/src/dsp/upsampling_neon.c
+    libwebp/src/dsp/upsampling_sse2.c
+    libwebp/src/dsp/upsampling_sse41.c
+    libwebp/src/dsp/yuv.c
+    libwebp/src/dsp/yuv_mips32.c
+    libwebp/src/dsp/yuv_mips_dsp_r2.c
+    libwebp/src/dsp/yuv_neon.c
+    libwebp/src/dsp/yuv_sse2.c
+    libwebp/src/dsp/yuv_sse41.c
+    libwebp/src/utils/bit_reader_utils.c
+    libwebp/src/utils/color_cache_utils.c
+    libwebp/src/utils/filters_utils.c
+    libwebp/src/utils/huffman_utils.c
+    libwebp/src/utils/quant_levels_dec_utils.c
+    libwebp/src/utils/random_utils.c
+    libwebp/src/utils/rescaler_utils.c
+    libwebp/src/utils/thread_utils.c
+    libwebp/src/utils/utils.c
+)
+set(LIBWEBP_INCLUDES
+    ${IMAGE_EXPORT_INCLUDES}
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${CMAKE_CURRENT_SOURCE_DIR}/libwebp
+)
+set(LIBWEBP_DEFINITIONS
+)
+set(LIBWEBP_LIBRARIES
+)
+
+add_definitions(-DWEBP_SWAP_16BIT_CSP=1)
+
+if(IMAGE_SINGLE_SHARED_LIB)
+    # Compile a static library for image-singlelib
+    set(LIBWEBP_LIBRARY_NAME image-webp-static)
+    set(LIBWEBP_LIBRARY_TYPE STATIC)
+    set(LIBWEBP_INCLUDES_VISIBILITY PUBLIC) # Share include dir with image project
+else()
+    # Compile a shared library to be imported by image-core
+    set(LIBWEBP_LIBRARY_NAME image-webp)
+    set(LIBWEBP_LIBRARY_TYPE SHARED)
+    set(LIBWEBP_INCLUDES_VISIBILITY PRIVATE)
+
+    # Link against image shared lib to get helper methods
+    set(LIBWEBP_LIBRARIES
+        ${LIBWEBP_LIBRARIES}
+        image
+        log
+    )
+endif()
+
+add_library(${LIBWEBP_LIBRARY_NAME} ${LIBWEBP_LIBRARY_TYPE} ${LIBWEBP_SOURCES})
+target_include_directories(${LIBWEBP_LIBRARY_NAME} ${LIBWEBP_INCLUDES_VISIBILITY}
+${LIBWEBP_INCLUDES})
+target_compile_definitions(${LIBWEBP_LIBRARY_NAME} PRIVATE ${LIBWEBP_DEFINITIONS})
+target_link_libraries(${LIBWEBP_LIBRARY_NAME} PRIVATE ${LIBWEBP_LIBRARIES})

--- a/library/src/main/jni/webp/CMakeLists.txt
+++ b/library/src/main/jni/webp/CMakeLists.txt
@@ -92,6 +92,7 @@ set(LIBWEBP_LIBRARIES
 )
 
 add_definitions(-DWEBP_SWAP_16BIT_CSP=1)
+add_definitions(-DWEBP_HAVE_NEON_RTCD)
 
 if(IMAGE_SINGLE_SHARED_LIB)
     # Compile a static library for image-singlelib

--- a/library/src/main/jni/webp/image_webp.c
+++ b/library/src/main/jni/webp/image_webp.c
@@ -543,14 +543,14 @@ bool webp_decode_buffer(Stream* stream, bool clip, uint32_t x, uint32_t y, uint3
     }
 
     // Set region to decode
-    webp_config.options.use_cropping = 1;
+    webp_config.options.use_cropping = clip;
     webp_config.options.crop_left = x;
     webp_config.options.crop_top = y;
     webp_config.options.crop_width = width;
     webp_config.options.crop_height = height;
 
     // Set scaled size
-    webp_config.options.use_scaling = 1;
+    webp_config.options.use_scaling = ratio != 1;
     webp_config.options.scaled_width = d_width;
     webp_config.options.scaled_height = d_height;
 

--- a/library/src/main/jni/webp/image_webp.c
+++ b/library/src/main/jni/webp/image_webp.c
@@ -15,6 +15,7 @@
  */
 
 #include <stdlib.h>
+#include <image_info.h>
 
 #include "image.h"
 #include "image_webp.h"
@@ -467,18 +468,18 @@ void* webp_decode(Stream* stream, bool partially, bool* animated) {
 bool webp_decode_info(Stream* stream, ImageInfo* info) {
     size_t bytes_to_read = 30;
     uint8_t data[bytes_to_read];
-    int width = 0;
-    int height = 0;
 
     stream->read(stream, data, bytes_to_read);
 
-    if (!WebPGetInfo(data, bytes_to_read, &width, &height)) {
+    WebPBitstreamFeatures features;
+    if (WebPGetFeatures(data, bytes_to_read, &features) != VP8_STATUS_OK) {
         LOGE("Failed to parse webp");
         return false;
     }
 
-    info->width = (uint32_t) width;
-    info->height = (uint32_t) height;
+    info->width = (uint32_t) features.width;
+    info->height = (uint32_t) features.height;
+    info->opaque = !features.has_alpha;
 
     return true;
 }

--- a/library/src/main/jni/webp/image_webp.c
+++ b/library/src/main/jni/webp/image_webp.c
@@ -1,0 +1,582 @@
+/*
+ * Copyright 2015 Hippo Seven
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdlib.h>
+
+#include "image.h"
+#include "image_webp.h"
+#include "image_utils.h"
+#include "image_decoder.h"
+#include "image_convert.h"
+#include "animated_image.h"
+#include "../log.h"
+
+
+#define IMAGE_WEBP_PREPARE_NONE 0x00
+#define IMAGE_WEBP_PREPARE_BACKGROUND 0x01
+
+
+typedef struct {
+    uint32_t width;
+    uint32_t height;
+    uint32_t offset_x;
+    uint32_t offset_y;
+    uint32_t delay; // ms
+    WebPMuxAnimDispose disposal;
+    WebPMuxAnimBlend blend;
+    uint8_t prepare;
+    uint8_t* buffer;
+} WebPFrame;
+
+typedef struct {
+    WebPFrame* frames;
+    uint32_t frame_count;
+    uint32_t background_color;
+    Stream* stream;
+    WebPDemuxer *demux;
+    WebPIterator *iterator;
+} WebPAnimData;
+
+
+LIBRARY_EXPORT
+bool webp_init(ImageLibrary* library) {
+    library->loaded = true;
+    library->is_magic = webp_is_magic;
+    library->decode = webp_decode;
+    library->decode_info = webp_decode_info;
+    library->decode_buffer = webp_decode_buffer;
+    library->create = NULL;
+    library->get_description = webp_get_description;
+
+    return true;
+}
+
+bool webp_is_magic(Stream* stream) {
+    uint8_t magic[2];
+
+    size_t read = stream->peek(stream, magic, sizeof(magic));
+    if (read != sizeof(magic)) {
+        LOGE(MSG("Could not read %zu bytes from stream, only read %zu"), sizeof(magic), read);
+        return false;
+    }
+
+    return magic[0] == IMAGE_WEBP_MAGIC_NUMBER_0 && magic[1] == IMAGE_WEBP_MAGIC_NUMBER_1;
+}
+
+const char* webp_get_description() {
+    return IMAGE_WEBP_DECODER_DESCRIPTION;
+}
+
+
+static inline void blend_over(uint8_t* dp, const uint8_t* sp, size_t len) {
+    uint32_t i;
+    uint32_t u, v, al;
+
+    for (i = 0; i < len; i += 4, sp += 4, dp += 4) {
+        if (sp[3] == 255) {
+            memcpy(dp, sp, 4);
+        } else if (sp[3] != 0) {
+            if (dp[3] != 0) {
+                u = sp[3] * 255u;
+                v = (255u - sp[3]) * dp[3];
+                al = u + v;
+                dp[0] = (uint8_t) ((sp[0] * u + dp[0] * v) / al);
+                dp[1] = (uint8_t) ((sp[1] * u + dp[1] * v) / al);
+                dp[2] = (uint8_t) ((sp[2] * u + dp[2] * v) / al);
+                dp[3] = (uint8_t) (al / 255u);
+            } else {
+                memcpy(dp, sp, 4);
+            }
+        }
+    }
+}
+
+static void blend(uint8_t* dst, uint32_t dst_width, uint32_t dst_height,
+                  uint8_t* src, uint32_t src_width, uint32_t src_height,
+                  uint32_t offset_x, uint32_t offset_y, bool blend_op_over) {
+    uint32_t i;
+    uint8_t* src_ptr;
+    uint8_t* dst_ptr;
+    size_t len;
+    uint32_t copy_width = MIN(dst_width - offset_x, src_width);
+    uint32_t copy_height = MIN(dst_height - offset_y, src_height);
+
+    for (i = 0; i < copy_height; i++) {
+        src_ptr = src + (i * src_width * 4);
+        dst_ptr = dst + (((offset_y + i) * dst_width + offset_x) * 4);
+        len = (size_t) (copy_width * 4);
+
+        if (blend_op_over) {
+            blend_over(dst_ptr, src_ptr, len);
+        } else {
+            memcpy(dst_ptr, src_ptr, len);
+        }
+    }
+}
+
+static void read_frame(WebPIterator *iter, WebPFrame *frame, WebPFrame *pre_frame) {
+    frame->buffer = WebPDecodeRGBA(iter->fragment.bytes, iter->fragment.size, (int*) &frame->width, (int*) &frame->height);
+    frame->offset_x = (uint32_t) iter->x_offset;
+    frame->offset_y = (uint32_t) iter->y_offset;
+    frame->delay = (uint32_t) iter->duration;
+    frame->disposal = iter->dispose_method;
+    frame->blend = iter->blend_method;
+
+    WebPMuxAnimDispose pre_disposal = pre_frame != NULL ? pre_frame->disposal : WEBP_MUX_DISPOSE_BACKGROUND;
+    switch (pre_disposal) {
+        case WEBP_MUX_DISPOSE_NONE:
+            frame->prepare = IMAGE_WEBP_PREPARE_NONE;
+            break;
+        default:
+        case WEBP_MUX_DISPOSE_BACKGROUND:
+            frame->prepare = IMAGE_WEBP_PREPARE_BACKGROUND;
+            break;
+    }
+}
+
+static void free_frames(WebPFrame** frames, size_t count) {
+    WebPFrame* frame_info;
+    size_t i;
+
+    if (frames == NULL || *frames == NULL) {
+        return;
+    }
+
+    for (i = 0; i < count; i++) {
+        frame_info = *frames + i;
+        free(frame_info->buffer);
+        frame_info->buffer = NULL;
+    }
+    free(*frames);
+    *frames = NULL;
+}
+
+Stream *get_stream(AnimatedImage *image) {
+    return ((WebPAnimData*) image->data)->stream;
+}
+
+void complete(AnimatedImage *image) {
+    WebPAnimData* data = image->data;
+    WebPFrame* frame;
+    uint32_t i = 1;
+    uint32_t j;
+
+    if (image->completed || data->demux == NULL || data->iterator == NULL) {
+        return;
+    }
+
+
+}
+
+static uint32_t get_frame_count(AnimatedImage *image) {
+    return ((WebPAnimData*) image->data)->frame_count;
+}
+
+uint32_t get_delay(AnimatedImage *image, uint32_t frame) {
+    WebPAnimData* data = image->data;
+    if (frame >= data->frame_count) {
+        LOGE(MSG("Frame count is %ud, can't get delay of index %ud"), data->frame_count, frame);
+        return 0;
+    }
+    return (data->frames + frame)->delay;
+}
+
+uint32_t get_byte_count(AnimatedImage *image) {
+    uint32_t size = 0;
+    uint32_t i;
+    WebPFrame* frame;
+    WebPAnimData* data = image->data;
+    if (image->completed) {
+        for (i = 0; i < data->frame_count; i++) {
+            frame = data->frames + i;
+            size += frame->width * frame->height * 4;
+        }
+        return size;
+    } else {
+        LOGE(MSG("Can't call get_byte_count on Uncompleted AnimatedImage"));
+        return 0;
+    }
+}
+
+void advance(AnimatedImage *image, DelegateImage *dImage) {
+    WebPAnimData* data = image->data;
+    int32_t target_index = dImage->index + 1;
+    uint32_t width = image->width;
+    uint32_t height = image->height;
+    WebPFrame* frame;
+
+    if (target_index < 0 || target_index >= data->frame_count) {
+        target_index = 0;
+    }
+    if (target_index == dImage->index) {
+        return;
+    }
+
+    frame = data->frames + target_index;
+
+    // Prepare
+    switch (frame->prepare) {
+        case IMAGE_WEBP_PREPARE_NONE:
+            // Do nothing
+            break;
+        default:
+        case IMAGE_WEBP_PREPARE_BACKGROUND:
+            // Set transparent
+            memset(dImage->buffer, data->background_color, width * height * 4);
+            break;
+    }
+
+    blend(dImage->buffer, dImage->width, dImage->height,
+          frame->buffer, frame->width, frame->height, frame->offset_x, frame->offset_y,
+          frame->blend == WEBP_MUX_BLEND);
+
+    delegate_image_apply(dImage);
+
+    dImage->index = target_index;
+}
+
+void recycle(AnimatedImage **image) {
+    WebPAnimData *data;
+
+    if (image == NULL || *image == NULL) {
+        return;
+    }
+
+    data = (WebPAnimData*) (*image)->data;
+
+    if (data->iterator != NULL) {
+        WebPDemuxReleaseIterator(data->iterator);
+        free(data->iterator);
+        data->iterator = NULL;
+    }
+    if (data->demux != NULL) {
+        WebPDemuxDelete(data->demux);
+        data->demux = NULL;
+    }
+
+    if (data->stream != NULL) {
+        data->stream->close(&data->stream);
+        data->stream = NULL;
+    }
+
+    free(data);
+    (*image)->data = NULL;
+
+    free(*image);
+    *image = NULL;
+}
+
+void* webp_decode(Stream* stream, bool partially, bool* animated) {
+    void* result = NULL;
+    StaticImage* static_image = NULL;
+    AnimatedImage* animated_image = NULL;
+    WebPAnimData* webp_anim_data = NULL;
+    WebPDemuxer *demux = NULL;
+    WebPIterator *iter = NULL;
+    WebPFrame *frames = NULL;
+
+    size_t data_size = 0;
+    uint32_t frame_count = 1;
+    uint32_t background_color = 0;
+    uint32_t width;
+    uint32_t height;
+
+    uint8_t *data = stream_read_all(stream, &data_size);
+    if (data == NULL) {
+        WTF_OOM;
+        return NULL;
+    }
+
+    // Get features
+    WebPBitstreamFeatures features;
+    if (WebPGetFeatures(data, data_size, &features) != VP8_STATUS_OK) {
+        LOGW("Invalid webp info");
+        goto end;
+    }
+
+    width = (uint32_t) features.width;
+    height = (uint32_t) features.height;
+
+    // Init demuxer if the image is animated
+    if (features.has_animation) {
+        WebPData webp_data = {.bytes = data, .size = data_size};
+        demux = WebPDemux(&webp_data);
+
+        frame_count = WebPDemuxGetI(demux, WEBP_FF_FRAME_COUNT);
+        background_color = WebPDemuxGetI(demux, WEBP_FF_BACKGROUND_COLOR);
+    }
+
+    // Check there's at least one frame
+    if (frame_count == 0) {
+        LOGW("Invalid frame count");
+        goto end;
+    }
+
+    // If only one frame, decode all
+    if (frame_count == 1) {
+        partially = false;
+    }
+
+    if (features.has_animation) {
+        // Malloc iterator and frames
+        iter = (WebPIterator*) malloc(sizeof(WebPIterator));
+        frames = (WebPFrame*) malloc(frame_count * sizeof(WebPFrame));
+        if (iter == NULL || frames == NULL) {
+            WTF_OOM;
+            goto end;
+        }
+
+        // Set frame buffer NULL for safety
+        for (int i = 0; i < frame_count; i++) {
+            (frames + i)->buffer = NULL;
+        }
+
+        // Init iterator
+        if (!WebPDemuxGetFrame(demux, 1, iter)) {
+            goto end;
+        }
+
+        // Read first frame
+        read_frame(iter, frames, NULL);
+
+        // Read remaining frames if not partial
+        if (!partially) {
+            for (int i = 1; i < frame_count; i++) {
+                if (WebPDemuxNextFrame(iter)) {
+                    read_frame(iter, frames + i, frames + i - 1);
+                }
+            }
+        }
+
+        if (frame_count == 1) {
+            // For one-frame webp, use StaticImage
+            static_image = static_image_new(width, height);
+            if (static_image == NULL) {
+                WTF_OOM;
+                goto end;
+            }
+            memset(static_image->buffer, background_color, width * height * 4);
+            blend(static_image->buffer, width, height,
+                  frames->buffer, frames->width, frames->height,
+                  frames->offset_x, frames->offset_y, false);
+
+            // Free frames, don't need it anymore
+            free_frames(&frames, 1);
+
+            // Set final result
+            static_image->format = IMAGE_FORMAT_WEBP;
+            static_image->opaque = !features.has_alpha;
+            *animated = false;
+            result = static_image;
+            goto end;
+        } else {
+            // For multi-frame webp, use AnimatedImage
+            animated_image = (AnimatedImage *) malloc(sizeof(AnimatedImage));
+            webp_anim_data = (WebPAnimData *) malloc(sizeof(WebPAnimData));
+            if (animated_image == NULL || webp_anim_data == NULL) {
+                WTF_OOM;
+                goto end;
+            }
+
+            animated_image->width = width;
+            animated_image->height = height;
+            animated_image->format = IMAGE_FORMAT_WEBP;
+            animated_image->opaque = !features.has_alpha;
+            animated_image->completed = !partially;
+            animated_image->data = webp_anim_data;
+
+            animated_image->get_stream = &get_stream;
+            animated_image->complete = &complete;
+            animated_image->get_frame_count = &get_frame_count;
+            animated_image->get_delay = &get_delay;
+            animated_image->get_byte_count = &get_byte_count;
+            animated_image->advance = &advance;
+            animated_image->recycle = &recycle;
+
+            webp_anim_data->frames = frames;
+            webp_anim_data->frame_count = frame_count;
+            webp_anim_data->background_color = background_color;
+
+            if (partially) {
+                webp_anim_data->stream = stream;
+                webp_anim_data->iterator = iter;
+                webp_anim_data->demux = demux;
+            } else {
+                webp_anim_data->stream = NULL;
+                webp_anim_data->iterator = NULL;
+                webp_anim_data->demux = NULL;
+            }
+
+            *animated = true;
+            result = animated_image;
+            goto end;
+        }
+    } else {
+        // New static image
+        static_image = static_image_new(width, height);
+        if (static_image == NULL) {
+            goto end;
+        }
+
+        int row_size = features.width * 4;
+        size_t total_size = (size_t) (features.height * row_size);
+
+        // Start decompress
+        WebPDecodeRGBAInto(data, data_size, static_image->buffer, total_size, row_size);
+
+        static_image->format = IMAGE_FORMAT_WEBP;
+        static_image->opaque = !features.has_alpha;
+        result = static_image;
+        goto end;
+    }
+
+    end:
+
+    if (!partially || result == NULL) {
+        WebPDemuxReleaseIterator(iter);
+        free(iter);
+        WebPDemuxDelete(demux);
+    }
+
+    if (result == NULL) {
+        free_frames(&frames, frame_count);
+        free(animated_image);
+        free(webp_anim_data);
+        free(static_image);
+        if (stream != NULL) {
+            stream->close(&stream);
+        }
+    }
+
+    return result;
+}
+
+bool webp_decode_info(Stream* stream, ImageInfo* info) {
+    size_t bytes_to_read = 30;
+    uint8_t data[bytes_to_read];
+    int width = 0;
+    int height = 0;
+
+    stream->read(stream, data, bytes_to_read);
+
+    if (!WebPGetInfo(data, bytes_to_read, &width, &height)) {
+        LOGE("Failed to parse webp");
+        return false;
+    }
+
+    info->width = (uint32_t) width;
+    info->height = (uint32_t) height;
+
+    return true;
+}
+
+bool webp_decode_buffer(Stream* stream, bool clip, uint32_t x, uint32_t y, uint32_t width,
+                        uint32_t height, int32_t config, uint32_t ratio, BufferContainer* container) {
+
+    bool result = false;
+    uint8_t* d_buffer = NULL;
+
+    uint32_t d_width;
+    uint32_t d_height;
+
+    // Init a configuration object
+    WebPDecoderConfig webp_config;
+    if (!WebPInitDecoderConfig(&webp_config)) {
+        return false;
+    }
+
+    // Read the data from the stream
+    size_t buffer_size = 0;
+    uint8_t *buffer = stream_read_all(stream, &buffer_size);
+
+    // Set clip info
+    if (!clip) {
+        // Read image headers
+        uint32_t image_width = 0, image_height = 0;
+
+        if (!WebPGetInfo(buffer, buffer_size, (int *) &image_width, (int *) &image_height)) {
+            goto end;
+        }
+
+        // Decode full image
+        x = 0; y = 0; width = image_width; height = image_height;
+    }
+
+    // Set config to IMAGE_CONFIG_RGB_565 as default
+    if (config == IMAGE_CONFIG_AUTO) {
+        config = IMAGE_CONFIG_RGB_565;
+    }
+
+    // Set out color space
+    if (config == IMAGE_CONFIG_RGBA_8888) {
+        webp_config.output.colorspace = MODE_RGBA;
+    } else if (config == IMAGE_CONFIG_RGB_565) {
+        webp_config.output.colorspace = MODE_RGB_565;
+    } else {
+        LOGE("Invalid config: %d", config);
+        goto end;
+    }
+
+    // Fix width and height
+    width = floor_uint32_t(width, ratio);
+    height = floor_uint32_t(height, ratio);
+    d_width = width / ratio;
+    d_height = height / ratio;
+
+    if (d_width == 0 || d_height == 0) {
+        LOGE("Ratio is too large!");
+        result = true;
+        goto end;
+    }
+
+    // Set region to decode
+    webp_config.options.use_cropping = 1;
+    webp_config.options.crop_left = x;
+    webp_config.options.crop_top = y;
+    webp_config.options.crop_width = width;
+    webp_config.options.crop_height = height;
+
+    // Set scaled size
+    webp_config.options.use_scaling = 1;
+    webp_config.options.scaled_width = d_width;
+    webp_config.options.scaled_height = d_height;
+
+    // Create buffer
+    d_buffer = container->create_buffer(container, d_width, d_height, config);
+    if (d_buffer == NULL) { goto end; }
+
+    uint32_t row_size = d_width * get_depth_for_config(config);
+
+    // Save decoded data in external buffer
+    webp_config.output.u.RGBA.rgba = d_buffer;
+    webp_config.output.u.RGBA.size = row_size * d_height;
+    webp_config.output.u.RGBA.stride = row_size;
+    webp_config.output.is_external_memory = 1;
+
+    // Decode image
+    WebPDecode(buffer, buffer_size, &webp_config);
+
+    result = true;
+
+    end:
+    if (d_buffer != NULL) {
+        container->release_buffer(container, d_buffer);
+    }
+
+    WebPFreeDecBuffer(&webp_config.output);
+
+    return result;
+}

--- a/library/src/main/jni/webp/image_webp.h
+++ b/library/src/main/jni/webp/image_webp.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2015 Hippo Seven
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef IMAGE_IMAGE_WEBP_H
+#define IMAGE_IMAGE_WEBP_H
+
+
+#include <stdbool.h>
+
+#include "src/webp/decode.h"
+#include "src/webp/mux_types.h"
+#include "src/webp/demux.h"
+#include "image_library.h"
+#include "stream.h"
+
+
+#define IMAGE_WEBP_DECODER_DESCRIPTION ("libwebp " MAKESTRING(STRINGIZE, DEC_MAJ_VERSION) "." \
+                                        MAKESTRING(STRINGIZE, DEC_MIN_VERSION) "." \
+                                        MAKESTRING(STRINGIZE, DEC_REV_VERSION))
+
+#define IMAGE_WEBP_MAGIC_NUMBER_0 0x52
+#define IMAGE_WEBP_MAGIC_NUMBER_1 0x49
+
+
+bool webp_init(ImageLibrary* library);
+
+bool webp_is_magic(Stream* stream);
+
+const char* webp_get_description();
+
+void* webp_decode(Stream* stream, bool partially, bool* animated);
+
+bool webp_decode_info(Stream* stream, ImageInfo* info);
+
+bool webp_decode_buffer(Stream* stream, bool clip, uint32_t x, uint32_t y, uint32_t width,
+                       uint32_t height, int32_t config, uint32_t ratio, BufferContainer* container);
+
+
+#endif // IMAGE_IMAGE_WEBP_H

--- a/library/webp/AndroidManifest.xml
+++ b/library/webp/AndroidManifest.xml
@@ -1,0 +1,1 @@
+<manifest package="com.hippo.image.webp"/>

--- a/library/webp/build.gradle
+++ b/library/webp/build.gradle
@@ -1,0 +1,54 @@
+apply plugin: 'com.android.library'
+
+android {
+    compileSdkVersion rootProject.ext.compileSdkVersion
+    buildToolsVersion rootProject.ext.buildToolsVersion
+
+    sourceSets {
+        main {
+            java.srcDirs = []
+            manifest.srcFile 'AndroidManifest.xml'
+        }
+    }
+
+    packagingOptions {
+        // Do not include libimage.so in the codec aar
+        exclude '**/libimage.so'
+    }
+
+    defaultConfig {
+        minSdkVersion rootProject.ext.minSdkVersion
+        targetSdkVersion rootProject.ext.targetSdkVersion
+        versionCode rootProject.ext.versionCode
+        versionName rootProject.ext.versionName
+
+        externalNativeBuild {
+            cmake {
+                targets "image-webp"
+                arguments "-DANDROID_ARM_NEON=TRUE",
+                          "-DIMAGE_SINGLE_SHARED_LIB=FALSE"
+            }
+        }
+    }
+
+    buildTypes {
+        release {
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), '../proguard-rules.pro'
+        }
+    }
+
+    externalNativeBuild {
+        cmake {
+            path '../src/main/jni/CMakeLists.txt'
+        }
+    }
+}
+
+project.afterEvaluate {
+    externalNativeBuildDebug.dependsOn ':singlelib:javah'
+    externalNativeBuildRelease.dependsOn ':singlelib:javah'
+}
+
+// Publish arr without java source and java doc
+apply plugin: 'com.github.dcendents.android-maven'

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,10 +1,11 @@
 include ':app'
 
-include ':core', ':gif', ':jpeg', ':png'
+include ':core', ':gif', ':jpeg', ':png', ':webp'
 project(':core').projectDir = new File('library/core')
 project(':gif').projectDir = new File('library/gif')
 project(':jpeg').projectDir = new File('library/jpeg')
 project(':png').projectDir = new File('library/png')
+project(':webp').projectDir = new File('library/webp')
 
 include ':singlelib'
 project(':singlelib').projectDir = new File('library/singlelib')


### PR DESCRIPTION
This PR adds support for WebP images (animated too) and updates gradle and the SDK to the latest version available.

Motivation: some sites may be using webp images, and Skia already supports this, so I thought why not include it here too. I'll accept it if you don't want to support webp though :).

I've split this PR into as many commits as possible to help reviewing. I can remove some of them if desired or move to a different PR.

This PR uses the whole libwebp library (tag v0.6.1). I haven't found a "decoding only" fork, but the folders `enc` and `mux` could be deleted alongside some files inside `dsp` and `utils`. Those are not compiled anyways so it's probably not a problem.

The `complete` function in `image_webp` is unfinished, but I don't understand yet how it works (I saw in png you clear the frames' buffer starting from the second frame and start over, but I still don't understand it).

Also, I'm a bit concerned about memory management in `webp_decode` but I think it's fine.
