### PR TITLE
Initial steps to modularize image codecs

### DIFF
--- a/app/src/main/java/com/hippo/image/example/TestActivity.java
+++ b/app/src/main/java/com/hippo/image/example/TestActivity.java
@@ -122,9 +122,9 @@ public class TestActivity extends AppCompatActivity implements Runnable {
 
     private void test() {
         testImage();
-        //testBitmapDecoderDecodeInfo();
-        //testBitmapDecoderDecode();
-        //testBitmapRegionDecoderDecode();
+        testBitmapDecoderDecodeInfo();
+        testBitmapDecoderDecode();
+        testBitmapRegionDecoderDecode();
         Log.d(LOG_TAG, "Test Done!");
     }
 
@@ -135,8 +135,10 @@ public class TestActivity extends AppCompatActivity implements Runnable {
                 final ImageData imageData;
                 if (i == 0) {
                     imageData = Image.decode(mResources.openRawResource(res.id), false);
+                    Assert.assertNotNull(imageData);
                 } else {
                     imageData = Image.decode(mResources.openRawResource(res.id), true);
+                    Assert.assertNotNull(imageData);
                     imageData.complete();
                 }
                 final ImageRenderer imageRenderer = imageData.createImageRenderer();

--- a/library/src/main/java/com/hippo/image/Image.java
+++ b/library/src/main/java/com/hippo/image/Image.java
@@ -113,8 +113,8 @@ public final class Image {
      * Return decoder description of the image format,
      * {@code null} for invalid image format.
      */
-    public static String getDecoderDescription(int format) {
-        return nativeGetDecoderDescription(format);
+    public static String getLibraryDescription(int format) {
+        return nativeGetLibraryDescription(format);
     }
 
     /**
@@ -145,5 +145,5 @@ public final class Image {
 
     private static native int[] nativeGetSupportedImageFormats();
 
-    private static native String nativeGetDecoderDescription(int format);
+    private static native String nativeGetLibraryDescription(int format);
 }

--- a/library/src/main/jni/image/Android.mk
+++ b/library/src/main/jni/image/Android.mk
@@ -17,6 +17,8 @@ LOCAL_PATH := $(call my-dir)
 include $(CLEAR_VARS)
 include $(CLEAR_ABI)
 
+LOCAL_CFLAGS := -DIMAGE_SINGLE_SHARED_LIB
+
 LOCAL_MODULE := image
 LOCAL_SRC_FILES := \
     image.c \
@@ -37,7 +39,7 @@ LOCAL_SRC_FILES := \
 LOCAL_C_INCLUDES := \
     $(LOCAL_PATH)/javah \
     $(LOCAL_PATH)/stream
-LOCAL_LDLIBS := -llog -ljnigraphics -lGLESv2
+LOCAL_LDLIBS := -llog -ljnigraphics -lGLESv2 -ldl
 LOCAL_STATIC_LIBRARIES := jpeg-turbo png gif
 
 LOCAL_SRC_FILES_armeabi-v7a := \

--- a/library/src/main/jni/image/image.h
+++ b/library/src/main/jni/image/image.h
@@ -31,32 +31,21 @@
 #include "buffer_container.h"
 #include "stream.h"
 
-
 #define IMAGE_FORMAT_UNKNOWN com_hippo_image_Image_FORMAT_UNKNOWN
 
-#ifdef IMAGE_SUPPORT_PLAIN
 #define IMAGE_FORMAT_PLAIN com_hippo_image_Image_FORMAT_PLAIN
-#endif
 
-#ifdef IMAGE_SUPPORT_BMP
 #define IMAGE_FORMAT_BMP com_hippo_image_Image_FORMAT_BMP
-#endif
 
-#ifdef IMAGE_SUPPORT_JPEG
 #define IMAGE_FORMAT_JPEG com_hippo_image_Image_FORMAT_JPEG
-#endif
 
-#ifdef IMAGE_SUPPORT_PNG
 #define IMAGE_FORMAT_PNG com_hippo_image_Image_FORMAT_PNG
-#endif
 
-#ifdef IMAGE_SUPPORT_GIF
 #define IMAGE_FORMAT_GIF com_hippo_image_Image_FORMAT_GIF
-#endif
 
-#define IMAGE_MAX_SUPPORTED_FORMAT_COUNT 4
+#define IMAGE_FORMAT_MAX_COUNT 5
 
-#define IMAGE_MAGIC_NUMBER_BYTE_COUNT 2
+void init_image_libraries();
 
 void decode(Stream* stream, bool partially, bool* animated, void** image);
 
@@ -69,7 +58,7 @@ StaticImage* create(uint32_t width, uint32_t height, const uint8_t* data);
 
 int get_supported_formats(int *formats);
 
-const char *get_decoder_description(int format);
+const char *get_library_description(int format);
 
 
 #endif //IMAGE_IMAGE_H

--- a/library/src/main/jni/image/image_convert_neon.S
+++ b/library/src/main/jni/image/image_convert_neon.S
@@ -5,7 +5,6 @@
 
 .macro endfunc
         .size   \name, .-\name
-        .endfunc
         .purgem endfunc
 .endm
 
@@ -13,7 +12,6 @@
         .align  2
         .global \name
         .type   \name, %function
-        .func   \name
 .endm
 
 

--- a/library/src/main/jni/image/image_gif.h
+++ b/library/src/main/jni/image/image_gif.h
@@ -30,6 +30,7 @@
 
 #include "gif_lib.h"
 #include "animated_image.h"
+#include "image_library.h"
 #include "stream.h"
 
 
@@ -40,8 +41,13 @@
 #define IMAGE_GIF_MAGIC_NUMBER_0 0x47
 #define IMAGE_GIF_MAGIC_NUMBER_1 0x49
 
+bool gif_init(ImageLibrary* library);
 
-AnimatedImage* gif_decode(Stream* stream, bool partially);
+bool gif_is_magic(Stream* stream);
+
+const char* gif_get_description();
+
+AnimatedImage* gif_decode(Stream* stream, bool partially, bool* animated);
 
 bool gif_decode_info(Stream* stream, ImageInfo* info);
 

--- a/library/src/main/jni/image/image_jpeg.h
+++ b/library/src/main/jni/image/image_jpeg.h
@@ -29,8 +29,9 @@
 #include <stdio.h>
 
 #include "jpeglib.h"
-#include "static_image.h"
-#include "stream.h"
+#include "image_library.h"
+#include "static_image.h" // TODO: make this injectable into the library
+#include "stream.h" // TODO: make object injectable
 
 
 #define IMAGE_JPEG_DECODER_DESCRIPTION ("libjpeg-turbo " MAKESTRING(STRINGIZE, LIBJPEG_TURBO_VERSION))
@@ -38,8 +39,13 @@
 #define IMAGE_JPEG_MAGIC_NUMBER_0 0xFF
 #define IMAGE_JPEG_MAGIC_NUMBER_1 0xD8
 
+bool jpeg_init(ImageLibrary* library);
 
-StaticImage* jpeg_decode(Stream* stream);
+bool jpeg_is_magic(Stream* stream);
+
+const char* jpeg_get_description();
+
+StaticImage* jpeg_decode(Stream* stream, bool unused1, bool* animated);
 
 bool jpeg_decode_info(Stream* stream, ImageInfo* info);
 

--- a/library/src/main/jni/image/image_library.h
+++ b/library/src/main/jni/image/image_library.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2018 Hippo Seven
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//
+// Created by msm595 on 7/04/2018.
+//
+
+#ifndef IMAGE_LIBRARY_IMAGE_H
+#define IMAGE_LIBRARY_IMAGE_H
+
+#define LIBRARY_EXPORT __attribute__ ((visibility ("default")))
+
+struct ImageLibrary;
+typedef struct ImageLibrary ImageLibrary;
+
+typedef bool (*ImageLibraryInitFunc)(ImageLibrary* library);
+typedef bool (*ImageLibraryIsMagic)(Stream* stream);
+typedef void* (*ImageLibraryDecodeFunc)(Stream* stream, bool partially, bool* animated);
+typedef bool (*ImageLibraryDecodeInfoFunc)(Stream* stream, ImageInfo* info);
+typedef bool (*ImageLibraryDecodeBufferFunc)(Stream* stream, bool clip, uint32_t x, uint32_t y,
+    uint32_t width, uint32_t height, int32_t config, uint32_t ratio, BufferContainer* container);
+typedef StaticImage* (*ImageLibraryCreateFunc)(uint32_t width, uint32_t height, const uint8_t* data);
+typedef const char* (*ImageLibraryGetDescription)(void);
+
+struct ImageLibrary {
+  bool loaded;
+
+  ImageLibraryIsMagic is_magic;
+  ImageLibraryDecodeFunc decode;
+  ImageLibraryDecodeInfoFunc decode_info;
+  ImageLibraryDecodeBufferFunc decode_buffer;
+  ImageLibraryCreateFunc create;
+  ImageLibraryGetDescription get_description;
+};
+
+#endif //IMAGE_LIBRARY_IMAGE_H

--- a/library/src/main/jni/image/image_plain.c
+++ b/library/src/main/jni/image/image_plain.c
@@ -26,8 +26,21 @@
 
 #include "image.h"
 #include "image_plain.h"
+#include "image_library.h"
 #include "../log.h"
 
+LIBRARY_EXPORT
+bool plain_init(ImageLibrary* library) {
+  library->loaded = true;
+  library->is_magic = NULL;
+  library->decode = NULL;
+  library->decode_info = NULL;
+  library->decode_buffer = NULL;
+  library->create = plain_create;
+  library->get_description = NULL;
+
+  return true;
+}
 
 StaticImage* plain_create(uint32_t width, uint32_t height, const uint8_t* buffer) {
   StaticImage* image;

--- a/library/src/main/jni/image/image_png.c
+++ b/library/src/main/jni/image/image_png.c
@@ -61,6 +61,35 @@ typedef struct {
 } PngData;
 
 
+LIBRARY_EXPORT
+bool png_init(ImageLibrary* library) {
+  library->loaded = true;
+  library->is_magic = png_is_magic;
+  library->decode = png_decode;
+  library->decode_info = png_decode_info;
+  library->decode_buffer = png_decode_buffer;
+  library->create = NULL;
+  library->get_description = png_get_description;
+
+  return true;
+}
+
+bool png_is_magic(Stream* stream) {
+  uint8_t magic[2];
+
+  size_t read = stream->peek(stream, magic, sizeof(magic));
+  if (read != sizeof(magic)) {
+    LOGE(MSG("Could not read %zu bytes from stream, only read %zu"), sizeof(magic), read);
+    return false;
+  }
+
+  return magic[0] == IMAGE_PNG_MAGIC_NUMBER_0 && magic[1] == IMAGE_PNG_MAGIC_NUMBER_1;
+}
+
+const char* png_get_description() {
+  return IMAGE_PNG_DECODER_DESCRIPTION;
+}
+
 /**
  * Skip some rows
  */

--- a/library/src/main/jni/image/image_png.h
+++ b/library/src/main/jni/image/image_png.h
@@ -30,6 +30,7 @@
 #include <jmorecfg.h>
 
 #include "png.h"
+#include "image_library.h"
 #include "stream.h"
 
 
@@ -38,6 +39,12 @@
 #define IMAGE_PNG_MAGIC_NUMBER_0 0x89
 #define IMAGE_PNG_MAGIC_NUMBER_1 0x50
 
+
+bool png_init(ImageLibrary* library);
+
+bool png_is_magic(Stream* stream);
+
+const char* png_get_description();
 
 void* png_decode(Stream* stream, bool partially, bool* animated);
 

--- a/library/src/main/jni/image/java_wrapper.c
+++ b/library/src/main/jni/image/java_wrapper.c
@@ -242,7 +242,7 @@ Java_com_hippo_image_Image_nativeDestroyBuffer(__unused JNIEnv* env, __unused jc
 
 JNIEXPORT jintArray JNICALL
 Java_com_hippo_image_Image_nativeGetSupportedImageFormats(JNIEnv *env, __unused jclass clazz) {
-  int formats[IMAGE_MAX_SUPPORTED_FORMAT_COUNT];
+  int formats[IMAGE_FORMAT_MAX_COUNT];
   int count = get_supported_formats(formats);
   jintArray array = (*env)->NewIntArray(env, count);
   if (array == NULL) {
@@ -253,8 +253,8 @@ Java_com_hippo_image_Image_nativeGetSupportedImageFormats(JNIEnv *env, __unused 
 }
 
 JNIEXPORT jstring JNICALL
-Java_com_hippo_image_Image_nativeGetDecoderDescription(JNIEnv *env, __unused jclass clazz, jint format) {
-  const char *description = get_decoder_description(format);
+Java_com_hippo_image_Image_nativeGetLibraryDescription(JNIEnv *env, __unused jclass clazz, jint format) {
+  const char *description = get_library_description(format);
   if (description == NULL) {
     return NULL;
   } else {
@@ -708,6 +708,7 @@ JNI_OnLoad(JavaVM *vm, __unused void* reserved) {
   }
 
   java_stream_init(env);
+  init_image_libraries();
 
   INIT_SUCCEED = true;
   return JNI_VERSION_1_6;

--- a/library/src/main/jni/image/stream/stream.h
+++ b/library/src/main/jni/image/stream/stream.h
@@ -17,15 +17,13 @@ struct STREAM;
 typedef struct STREAM Stream;
 
 typedef size_t (*StreamReadFunc) (Stream* stream, void* buffer, size_t size);
-typedef bool   (*StreamMarkFunc) (Stream* stream, size_t limit);
-typedef void   (*StreamResetFunc)(Stream* stream);
+typedef size_t (*StreamPeekFunc) (Stream* stream, void* buffer, size_t size);
 typedef void   (*StreamCloseFunc)(Stream** stream);
 
 struct STREAM {
   void* data;
   StreamReadFunc  read;
-  StreamMarkFunc  mark;
-  StreamResetFunc reset;
+  StreamPeekFunc peek;
   StreamCloseFunc close;
 };
 

--- a/library/src/main/jni/libpng/arm/filter_neon.S
+++ b/library/src/main/jni/libpng/arm/filter_neon.S
@@ -43,7 +43,6 @@
 .macro  func    name, export=0
     .macro endfunc
 ELF     .size   \name, . - \name
-        .endfunc
         .purgem endfunc
     .endm
         .text
@@ -58,7 +57,6 @@ ELF     .size   \name, . - \name
         .global \name
     .endif
 ELF     .type   \name, STT_FUNC
-        .func   \name
 \name:
 .endm
 


### PR DESCRIPTION
This lays the groundwork to split the decoders into separate modules (https://github.com/seven332/Image/issues/10).

This PR cleans up Streams `mark`/`reset` with a cleaner `peek` function that has a simpler implementation. It also sets up a dynamic codec interface, so each codec can be loaded from separate shared libraries. They are currently all linked in the same shared library, the next PR will split them with the following outputs:

- `libimage-singlelib.so` - the current library with all codecs embedded
- `libimage.so` - the dynamic library with only the image_plain codec
- `libimage-jpeg.so` - the jpeg codec
- `libimage-png.so` - the png codec
- `libimage-gif.so` - the gif codec

This way users have the option of using the single lib if they need all the codecs, but can dynamically select codecs if they only need a few.

CC: @inorichi, since this effects your WebP PR.