### PR TITLE
Unset clip if decoding full image

### DIFF
--- a/library/src/main/java/com/hippo/image/BitmapRegionDecoder.java
+++ b/library/src/main/java/com/hippo/image/BitmapRegionDecoder.java
@@ -123,7 +123,7 @@ public final class BitmapRegionDecoder {
             }
 
             if (rect == null) {
-                return nativeDecodeRegion(mNativePtr, 0, 0, mWidth, mHeight, config, ratio);
+                return nativeDecodeRegion(mNativePtr, 0, 0, 0, 0, config, ratio);
             } else {
                 if (rect.right <= 0 || rect.bottom <= 0 || rect.left >= mWidth || rect.top >= mHeight || rect.isEmpty()) {
                     Log.e(LOG_TAG, "The decode rect is invalid.");

--- a/library/src/main/java/com/hippo/image/BitmapRegionDecoder.java
+++ b/library/src/main/java/com/hippo/image/BitmapRegionDecoder.java
@@ -122,7 +122,8 @@ public final class BitmapRegionDecoder {
                 config = mOpaque ? BitmapDecoder.CONFIG_RGB_565 : BitmapDecoder.CONFIG_RGBA_8888;
             }
 
-            if (rect == null) {
+            if (rect == null || (rect.left == 0 && rect.top == 0 && rect.right == mWidth && rect.bottom == mHeight)) {
+                // Requested full image, decode without regions
                 return nativeDecodeRegion(mNativePtr, 0, 0, 0, 0, config, ratio);
             } else {
                 if (rect.right <= 0 || rect.bottom <= 0 || rect.left >= mWidth || rect.top >= mHeight || rect.isEmpty()) {

--- a/library/src/main/jni/image/java_wrapper.c
+++ b/library/src/main/jni/image/java_wrapper.c
@@ -598,9 +598,12 @@ Java_com_hippo_image_BitmapRegionDecoder_nativeDecodeRegion(JNIEnv* env, __unuse
   container = bitmap_container_new(env, CLASS_BITMAP_DECODER, METHOD_BITMAP_DECODER_CREATE_BITMAP);
   if (container == NULL) { goto end; }
 
+  // Decode regions only if requested width and height are not 0
+  bool clip = width != 0 && height != 0;
+
   // Decode
   buffer_stream_reset(stream);
-  result = decode_buffer(stream, true, (uint32_t) x, (uint32_t) y,
+  result = decode_buffer(stream, clip, (uint32_t) x, (uint32_t) y,
       (uint32_t) width, (uint32_t) height, (int32_t) config, ratio < 1 ? 1 : (uint32_t) ratio, container);
   bitmap = bitmap_container_fetch_bitmap(container);
 


### PR DESCRIPTION
Minor optimization for region decoders when decoding the full image. The idea comes from the WebP PR where this flag being false improves performance by 2x.

I pass 0 as width and height because the `BitmapDecoder` also does this so it should work without issues.
