### PR TITLE
Add proguard keep annotations

### DIFF
--- a/library/src/main/java/com/hippo/image/AnimatedImage.java
+++ b/library/src/main/java/com/hippo/image/AnimatedImage.java
@@ -20,8 +20,10 @@ package com.hippo.image;
  * Created by Hippo on 8/4/2016.
  */
 
+import android.support.annotation.Keep;
 import android.support.annotation.NonNull;
 
+@Keep
 final class AnimatedImage implements ImageData {
 
     private long mNativePtr;

--- a/library/src/main/java/com/hippo/image/BitmapDecoder.java
+++ b/library/src/main/java/com/hippo/image/BitmapDecoder.java
@@ -22,6 +22,7 @@ package com.hippo.image;
 
 import android.graphics.Bitmap;
 import android.support.annotation.IntDef;
+import android.support.annotation.Keep;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.util.Log;
@@ -101,6 +102,7 @@ public final class BitmapDecoder {
     }
 
     // For native code
+    @Keep
     private static Bitmap createBitmap(int width, int height, int config) {
         final Bitmap.Config conf;
         switch (config) {

--- a/library/src/main/java/com/hippo/image/BitmapRegionDecoder.java
+++ b/library/src/main/java/com/hippo/image/BitmapRegionDecoder.java
@@ -22,6 +22,7 @@ package com.hippo.image;
 
 import android.graphics.Bitmap;
 import android.graphics.Rect;
+import android.support.annotation.Keep;
 import android.support.annotation.Nullable;
 import android.util.Log;
 
@@ -39,6 +40,7 @@ public final class BitmapRegionDecoder {
 
     private final Object mNativeLock = new Object();
 
+    @Keep
     private BitmapRegionDecoder(long nativePtr, int width, int height,
             int format, boolean opaque) {
         mNativePtr = nativePtr;

--- a/library/src/main/java/com/hippo/image/ImageInfo.java
+++ b/library/src/main/java/com/hippo/image/ImageInfo.java
@@ -20,6 +20,9 @@ package com.hippo.image;
  * Created by Hippo on 9/12/2016.
  */
 
+import android.support.annotation.Keep;
+
+@Keep
 public final class ImageInfo {
 
     public int width;

--- a/library/src/main/java/com/hippo/image/StaticImage.java
+++ b/library/src/main/java/com/hippo/image/StaticImage.java
@@ -20,8 +20,10 @@ package com.hippo.image;
  * Created by Hippo on 8/4/2016.
  */
 
+import android.support.annotation.Keep;
 import android.support.annotation.NonNull;
 
+@Keep
 final class StaticImage implements ImageData {
 
     private long mNativePtr;


### PR DESCRIPTION
This PR adds necessary `@Keep` annotations to methods and classes that are accessed by native code.

They are roughly equivalent to these proguard rules I currently use in my app:

```
-keep class com.hippo.image.StaticImage { *; }
-keep class com.hippo.image.AnimatedImage { *; }
-keep class com.hippo.image.ImageInfo { *; }

-keepclassmembers class com.hippo.image.BitmapDecoder {
    android.graphics.Bitmap createBitmap(int, int, int);
}

-keepclasseswithmembers class com.hippo.image.BitmapRegionDecoder {
    <init>(...);
}
```

This makes it possible to use this library with zero config on the consuming app side.

Tested this in a real app with R8 (full mode).